### PR TITLE
Use file:// URL for defPath to fix an issue with paths on Windows

### DIFF
--- a/commands/index.js
+++ b/commands/index.js
@@ -1,6 +1,7 @@
 const loadCommands = (async function () {
 	const fs = require("fs/promises");
 	const path = require("path");
+	const { platform } = require("os");
 
 	const commandList = await fs.readdir(__dirname, {
 		withFileTypes: true
@@ -12,7 +13,7 @@ const loadCommands = (async function () {
 	const dirList = commandList.filter((entry) => entry.isDirectory());
 	for (const dir of dirList) {
 		let def;
-		const baseDir = `file://${__dirname}`;
+		const baseDir = platform() === "win32" ? `file://${__dirname}` : __dirname;
 		const defPath = path.join(baseDir, dir.name, "index.js");
 		try {
 			const codeData = await import(defPath);

--- a/commands/index.js
+++ b/commands/index.js
@@ -12,12 +12,14 @@ const loadCommands = (async function () {
 	const dirList = commandList.filter((entry) => entry.isDirectory());
 	for (const dir of dirList) {
 		let def;
-		const defPath = path.join(__dirname, dir.name, "index.js");
+		const baseDir = `file://${__dirname}`;
+		const defPath = path.join(baseDir, dir.name, "index.js");
 		try {
 			const codeData = await import(defPath);
 			def = codeData.default;
 		}
-		catch {
+		catch (e) {
+			console.error(e);
 			failed.push(dir.name);
 		}
 


### PR DESCRIPTION
This PR uses the `file://` protocol for absolute paths for commands. And now the `commands/index.js` file also logs the error in the console.

Fixes #47.